### PR TITLE
Speculate sense outcomes in MHT and ingest those in strategy functions

### DIFF
--- a/reconchess_tools/utilities.py
+++ b/reconchess_tools/utilities.py
@@ -20,7 +20,7 @@ def simulate_sense(
     assert square in list(chess.SQUARES), f"{square} is not a valid square."
     rank, file = chess.square_rank(square), chess.square_file(square)
     sense_result = []
-    for delta_rank in [1, 0, -1]:
+    for delta_rank in [-1, 0, 1]:
         for delta_file in [-1, 0, 1]:
             if 0 <= rank + delta_rank <= 7 and 0 <= file + delta_file <= 7:
                 sense_square = chess.square(file + delta_file, rank + delta_rank)


### PR DESCRIPTION
This PR refactors the sense strategy functions so that the board set partitioning over all possible sense choices and outcomes is handled by the MultiHypothesisTracker. The result is stored in mht.sense_speculation and used as a lookup when present. It is also useful for screening dominated sense squares and finding the minimax sense square.